### PR TITLE
Remove dynamics from AssetTypes

### DIFF
--- a/Castaway.Assets/Asset.cs
+++ b/Castaway.Assets/Asset.cs
@@ -38,8 +38,5 @@ public class Asset
 		return _bytes ?? throw new InvalidOperationException("Not loaded.");
 	}
 
-	public T To<T>()
-	{
-		return Type.To<T>(this);
-	}
+	public T? Read<T>() where T : class => Type.Read<T>(this);
 }

--- a/Castaway.Assets/IAssetType.cs
+++ b/Castaway.Assets/IAssetType.cs
@@ -1,6 +1,12 @@
+using System;
+
 namespace Castaway.Assets;
 
 public interface IAssetType
 {
-	T To<T>(Asset a);
+	T Read<T>(Asset a) => Read(a) is T t
+		? t
+		: throw new InvalidCastException($"Read<T>() couldn't cast into {typeof(T).FullName}");
+
+	object Read(Asset a);
 }

--- a/Castaway.Assets/TextAssetType.cs
+++ b/Castaway.Assets/TextAssetType.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text;
 
 namespace Castaway.Assets;
@@ -6,10 +5,5 @@ namespace Castaway.Assets;
 [Loads("txt")]
 public class TextAssetType : IAssetType
 {
-	public T To<T>(Asset a)
-	{
-		if (typeof(T) == typeof(string))
-			return (T)(dynamic)Encoding.UTF8.GetString(a.GetBytes());
-		throw new InvalidOperationException($"Cannot convert TextAssetType to {typeof(T).FullName}");
-	}
+	public object Read(Asset a) => Encoding.UTF8.GetString(a.GetBytes());
 }

--- a/Castaway.Assets/XMLAssetType.cs
+++ b/Castaway.Assets/XMLAssetType.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Text;
 using System.Xml;
 
@@ -7,17 +6,10 @@ namespace Castaway.Assets;
 [Loads("xml")]
 public class XmlAssetType : IAssetType
 {
-	public virtual T To<T>(Asset a)
+	public virtual object Read(Asset a)
 	{
-		if (typeof(T) == typeof(string))
-			return (T)(dynamic)Encoding.UTF8.GetString(a.GetBytes());
-		if (typeof(T) == typeof(XmlDocument))
-		{
-			var d = new XmlDocument();
-			d.LoadXml(To<string>(a));
-			return (T)(dynamic)d;
-		}
-
-		throw new InvalidOperationException($"Cannot convert XMLAssetType to {typeof(T).FullName}");
+		var d = new XmlDocument();
+		d.LoadXml(Encoding.UTF8.GetString(a.GetBytes()));
+		return d;
 	}
 }

--- a/Castaway.Base/CastawayGlobal.cs
+++ b/Castaway.Base/CastawayGlobal.cs
@@ -115,8 +115,9 @@ public static class CastawayGlobal
 					application.Render();
 					application.Update();
 					var r = stopwatch.Elapsed.TotalSeconds;
+					// TODO Custom FPS targets
+					Thread.Sleep(TimeSpan.FromMilliseconds(Math.Max(15.0 - r, 0)));
 					application.EndFrame();
-					Thread.Sleep((int)Math.Max(16 - stopwatch.ElapsedMilliseconds, 0));
 					RealFrameTime = r;
 					FrameTime = stopwatch.Elapsed.TotalSeconds;
 #if RELEASE

--- a/Castaway.Level/Controllers/MeshController.cs
+++ b/Castaway.Level/Controllers/MeshController.cs
@@ -27,7 +27,7 @@ public class MeshController : Controller
 
 	private Mesh ResolveNormally()
 	{
-		return Asset!.Type.To<Mesh>(Asset);
+		return Asset!.Type.Read<Mesh>(Asset);
 	}
 
 	private Mesh ResolveNormallyAndCache()

--- a/Castaway.Level/Level.cs
+++ b/Castaway.Level/Level.cs
@@ -39,7 +39,7 @@ public class Level : IDisposable
 
 	public Level(Asset asset) : this()
 	{
-		var doc = asset.Type.To<XmlDocument>(asset);
+		var doc = asset.Type.Read<XmlDocument>(asset);
 		var root = doc.DocumentElement;
 
 		var node = root!.FirstChild;

--- a/Castaway.OpenGL.Controllers/ShaderController.cs
+++ b/Castaway.OpenGL.Controllers/ShaderController.cs
@@ -65,7 +65,7 @@ public class ShaderController : Controller
 
 	private void ResolveNormally()
 	{
-		Shader = AssetLoader.Loader!.GetAssetByName(AssetName).To<ShaderObject>();
+		Shader = AssetLoader.Loader!.GetAssetByName(AssetName).Read<ShaderObject>();
 		Logger.Debug("Resolved shader with asset at {Path}", AssetName);
 	}
 

--- a/Castaway.OpenGL/BuiltinShaders.cs
+++ b/Castaway.OpenGL/BuiltinShaders.cs
@@ -62,7 +62,7 @@ internal class BuiltinShaders : IShaderProvider
 		var asm = Assembly.GetExecutingAssembly();
 		using var stream = asm.GetManifestResourceStream($"Castaway.OpenGL._shaders.{path}");
 		var reader = new StreamReader(stream!);
-		return ShaderAssetType.LoadOpenGL(reader.ReadToEnd(),
+		return ShaderAssetType.LoadOpenGl(reader.ReadToEnd(),
 			$"manifest:Castaway.OpenGL:Castaway.OpenGL._shaders.{path}");
 	}
 }

--- a/Castaway.OpenGL/ImageAssetType.cs
+++ b/Castaway.OpenGL/ImageAssetType.cs
@@ -1,4 +1,3 @@
-using System;
 using System.IO;
 using Castaway.Assets;
 using SixLabors.ImageSharp;
@@ -8,11 +7,9 @@ namespace Castaway.OpenGL;
 [Loads("png", "jpg", "jpeg")]
 public class ImageAssetType : IAssetType
 {
-	public T To<T>(Asset a)
+	public object Read(Asset a)
 	{
-		if (typeof(T) != typeof(Image))
-			throw new InvalidOperationException($"Cannot convert ImageAssetType to {typeof(T).FullName}");
 		using var s = new MemoryStream(a.GetBytes());
-		return (T)(dynamic)Image.Load(s);
+		return Image.Load(s);
 	}
 }

--- a/Castaway.OpenGL/ShaderAssetType.cs
+++ b/Castaway.OpenGL/ShaderAssetType.cs
@@ -48,22 +48,22 @@ public class ShaderAssetType : XmlAssetType
 		[VertexInputType.TextureSTV] = "vec3"
 	};
 
-	public override T To<T>(Asset a)
+	public override object Read(Asset a)
 	{
-		if (typeof(T) == typeof(ShaderObject))
-			return (T)(dynamic)LoadOpenGL(base.To<XmlDocument>(a), a.Index);
-		return base.To<T>(a);
+		return LoadOpenGl(
+			base.Read(a) as XmlDocument ?? throw new ArgumentException("Asset is not an XML document", nameof(a)),
+			a.Index);
 	}
 
-	public static ShaderObject LoadOpenGL(string str, string path)
+	public static ShaderObject LoadOpenGl(string str, string path)
 	{
 		Logger.Debug("Loading shader from {Path}", path);
 		var doc = new XmlDocument();
 		doc.LoadXml(str);
-		return LoadOpenGL(doc, path);
+		return LoadOpenGl(doc, path);
 	}
 
-	public static ShaderObject LoadOpenGL(XmlDocument doc, string path)
+	public static ShaderObject LoadOpenGl(XmlDocument doc, string path)
 	{
 		var g = Graphics.Current;
 		var root = doc.DocumentElement;

--- a/Castaway.OpenGL/ShaderPart.cs
+++ b/Castaway.OpenGL/ShaderPart.cs
@@ -38,7 +38,7 @@ internal sealed class ShaderPart : SeparatedShaderObject
 		if (!CompileSuccess) throw new GraphicsException($"Failed to compile {stage} shader");
 	}
 
-	public ShaderPart(ShaderStage stage, Asset asset) : this(stage, asset.To<string>(), asset.Index)
+	public ShaderPart(ShaderStage stage, Asset asset) : this(stage, asset.Read<string>(), asset.Index)
 	{
 	}
 

--- a/Castaway.Rendering/WavefrontOBJAssetType.cs
+++ b/Castaway.Rendering/WavefrontOBJAssetType.cs
@@ -1,20 +1,16 @@
-using System;
 using System.Text;
 using Castaway.Assets;
 using Castaway.Rendering.MeshLoader;
-using Castaway.Rendering.Structures;
 
 namespace Castaway.Rendering;
 
 [Loads("obj", "mtl")]
-public class WavefrontOBJAssetType : IAssetType
+public class WavefrontObjAssetType : IAssetType
 {
-	public T To<T>(Asset a)
+	public object Read(Asset a)
 	{
-		if (typeof(T) == typeof(string))
-			return (T)(dynamic)Encoding.UTF8.GetString(a.GetBytes());
-		if (typeof(T) == typeof(Mesh))
-			return (T)(dynamic)WavefrontOBJ.ReadMesh(To<string>(a).Split('\n')).Result;
-		throw new InvalidOperationException($"Cannot convert {nameof(WavefrontOBJAssetType)} to {typeof(T).Name}");
+		return WavefrontOBJ.ReadMesh(
+				Encoding.UTF8.GetString(a.GetBytes()).Split('\n'))
+			.Result;
 	}
 }


### PR DESCRIPTION
Breaking change to remove `dynamic` use from AssetType implementations.