### PR TITLE
Support property controller values

### DIFF
--- a/Castaway.Level/Controllers/TestController.cs
+++ b/Castaway.Level/Controllers/TestController.cs
@@ -7,9 +7,8 @@ namespace Castaway.Level.Controllers;
 [ControllerName("Test")]
 public class TestController : Controller
 {
-	[LevelSerialized("Test1")] public int Test1;
-
-	[LevelSerialized("Test2")] public int Test2;
+	[LevelSerialized("Test1")] public int Test1 { get; set; }
+	[LevelSerialized("Test2")] public int Test2 { get; set; }
 
 	public override void OnInit(LevelObject parent)
 	{

--- a/Castaway.Level/Level.cs
+++ b/Castaway.Level/Level.cs
@@ -97,13 +97,21 @@ public class Level : IDisposable
 			var n = on as XmlNode;
 			try
 			{
-				var f = t.GetFields().Single(field =>
+				var memberInfo = t.GetFields().Concat<MemberInfo>(t.GetProperties()).Single(m =>
 				{
-					var a = field.GetCustomAttribute<LevelSerializedAttribute>();
+					var a = m.GetCustomAttribute<LevelSerializedAttribute>();
 					if (a == null) return false;
 					return a.Name == n!.Name;
 				});
-				f.SetValue(inst, Load(f.FieldType, n!.InnerText));
+				switch (memberInfo)
+				{
+					case FieldInfo fieldInfo:
+						fieldInfo.SetValue(inst, Load(fieldInfo.FieldType, n!.InnerText));
+						break;
+					case PropertyInfo propertyInfo:
+						propertyInfo.SetValue(inst, Load(propertyInfo.PropertyType, n!.InnerText));
+						break;
+				}
 			}
 			catch (InvalidOperationException exc)
 			{

--- a/Castaway.Level/LevelSerializedAttribute.cs
+++ b/Castaway.Level/LevelSerializedAttribute.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Castaway.Level;
 
-[AttributeUsage(AttributeTargets.Field)]
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
 public class LevelSerializedAttribute : Attribute
 {
 	public string Name;


### PR DESCRIPTION
Adds support for using `[LevelSerialized]` on properties. The property only needs to have a setter to be usable by the deserializer.